### PR TITLE
fix: updated path for new structure in referenced repo

### DIFF
--- a/slim/datasets/imagenet.py
+++ b/slim/datasets/imagenet.py
@@ -83,7 +83,7 @@ def create_readable_names_for_imagenet_labels():
   """
 
   # pylint: disable=g-line-too-long
-  base_url = 'https://raw.githubusercontent.com/tensorflow/models/master/research/inception/inception/data/'
+  base_url = 'https://raw.githubusercontent.com/tensorflow/models/master/research/slim/datasets/'
   synset_url = '{}/imagenet_lsvrc_2015_synsets.txt'.format(base_url)
   synset_to_human_url = '{}/imagenet_metadata.txt'.format(base_url)
 


### PR DESCRIPTION
The referenced file has moved in commit [2430](https://github.com/tensorflow/models/pull/2430) of the original repo.

Context: I was trying to use the [Image Tutorial](https://github.com/marcotcr/lime/blob/master/doc/notebooks/Tutorial%20-%20images.ipynb) of Lime, which references this tf-models fork. Unfortunately, there are several broken links.
This can be easily replaced by this new path.